### PR TITLE
Finalize auth + theming + notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,12 @@ import { NavigationContainer } from '@react-navigation/native';
 import Navigation from './navigation';
 import { Provider as PaperProvider } from 'react-native-paper';
 import { AppProvider } from './context/AppContext';
+import { theme } from './theme';
 
 export default function App() {
   return (
     <AppProvider>
-      <PaperProvider>
+      <PaperProvider theme={theme}>
         <NavigationContainer>
           <Navigation />
         </NavigationContainer>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,16 +1,22 @@
 import React, { createContext, useContext, useReducer } from 'react';
+import { Snackbar } from 'react-native-paper';
+import * as auth from '../services/auth';
 
 interface State {
   user: string | null;
+  notification: string | null;
 }
 
 const initialState: State = {
   user: null,
+  notification: null,
 };
 
 type Action =
   | { type: 'login'; user: string }
-  | { type: 'logout' };
+  | { type: 'logout' }
+  | { type: 'notify'; message: string }
+  | { type: 'clearNotification' };
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -18,27 +24,55 @@ function reducer(state: State, action: Action): State {
       return { ...state, user: action.user };
     case 'logout':
       return { ...state, user: null };
+    case 'notify':
+      return { ...state, notification: action.message };
+    case 'clearNotification':
+      return { ...state, notification: null };
     default:
       return state;
   }
 }
 
-const AppContext = createContext<{ state: State; dispatch: React.Dispatch<Action>; login: (email: string, password: string) => void }>({
+const AppContext = createContext<{
+  state: State;
+  dispatch: React.Dispatch<Action>;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  showNotification: (message: string) => void;
+}>({
   state: initialState,
   dispatch: () => null,
-  login: () => {},
+  login: async () => {},
+  logout: () => {},
+  showNotification: () => {},
 });
 
 export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  const login = (email: string, password: string) => {
-    dispatch({ type: 'login', user: email });
+  const login = async (email: string, password: string) => {
+    const result = await auth.login(email, password);
+    dispatch({ type: 'login', user: result.email });
+    dispatch({ type: 'notify', message: 'Logged in' });
   };
 
+  const logout = () => {
+    dispatch({ type: 'logout' });
+    dispatch({ type: 'notify', message: 'Logged out' });
+  };
+
+  const showNotification = (message: string) => {
+    dispatch({ type: 'notify', message });
+  };
+
+  const onDismissSnackBar = () => dispatch({ type: 'clearNotification' });
+
   return (
-    <AppContext.Provider value={{ state, dispatch, login }}>
+    <AppContext.Provider value={{ state, dispatch, login, logout, showNotification }}>
       {children}
+      <Snackbar visible={!!state.notification} onDismiss={onDismissSnackBar}>
+        {state.notification}
+      </Snackbar>
     </AppContext.Provider>
   );
 };

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -6,18 +6,26 @@ import ProductDetailScreen from '../screens/ProductDetailScreen';
 import CameraScreen from '../screens/CameraScreen';
 import ProfileScreen from '../screens/ProfileScreen';
 import NotificationsScreen from '../screens/NotificationsScreen';
+import { useApp } from '../context/AppContext';
 
 const Stack = createNativeStackNavigator();
 
 export default function Navigation() {
+  const { state } = useApp();
+
   return (
-    <Stack.Navigator initialRouteName="Login">
-      <Stack.Screen name="Login" component={LoginScreen} />
-      <Stack.Screen name="Home" component={HomeScreen} />
-      <Stack.Screen name="Product" component={ProductDetailScreen} />
-      <Stack.Screen name="Camera" component={CameraScreen} />
-      <Stack.Screen name="Profile" component={ProfileScreen} />
-      <Stack.Screen name="Notifications" component={NotificationsScreen} />
+    <Stack.Navigator>
+      {state.user ? (
+        <>
+          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="Product" component={ProductDetailScreen} />
+          <Stack.Screen name="Camera" component={CameraScreen} />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
+          <Stack.Screen name="Notifications" component={NotificationsScreen} />
+        </>
+      ) : (
+        <Stack.Screen name="Login" component={LoginScreen} />
+      )}
     </Stack.Navigator>
   );
 }

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,22 +1,32 @@
 import React, { useState } from 'react';
-import { View, TextInput, Button } from 'react-native';
+import { View } from 'react-native';
+import { TextInput, Button } from 'react-native-paper';
 import { useApp } from '../context/AppContext';
+import { useNavigation } from '@react-navigation/native';
 
 export default function LoginScreen() {
   const { login } = useApp();
+  const navigation = useNavigation();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
+  const onLogin = async () => {
+    await login(email, password);
+    navigation.navigate('Home' as never);
+  };
+
   return (
     <View>
-      <TextInput value={email} onChangeText={setEmail} placeholder="Email" />
+      <TextInput value={email} onChangeText={setEmail} label="Email" />
       <TextInput
         value={password}
         onChangeText={setPassword}
-        placeholder="Password"
+        label="Password"
         secureTextEntry
       />
-      <Button title="Login" onPress={() => login(email, password)} />
+      <Button mode="contained" onPress={onLogin}>
+        Login
+      </Button>
     </View>
   );
 }

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
+import { Button, Text } from 'react-native-paper';
+import { useApp } from '../context/AppContext';
 
 export default function NotificationsScreen() {
+  const { showNotification } = useApp();
+
   return (
     <View>
-      <Text>Notifications</Text>
+      <Text variant="titleMedium">Notifications</Text>
+      <Button onPress={() => showNotification('New notification!')}>Test</Button>
     </View>
   );
 }

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -2,4 +2,9 @@ import { MD3LightTheme as DefaultTheme } from 'react-native-paper';
 
 export const theme = {
   ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    primary: '#6750A4',
+    secondary: '#625B71',
+  },
 };

--- a/tests/login.test.tsx
+++ b/tests/login.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import LoginScreen from '../src/screens/LoginScreen';
+import { AppProvider } from '../src/context/AppContext';
+
+jest.useFakeTimers();
+
+it('shows snackbar on login', async () => {
+  const { getByLabelText, getByText } = render(
+    <AppProvider>
+      <LoginScreen />
+    </AppProvider>
+  );
+
+  fireEvent.changeText(getByLabelText('Email'), 'test@example.com');
+  fireEvent.changeText(getByLabelText('Password'), 'secret');
+  fireEvent.press(getByText('Login'));
+
+  await waitFor(() => expect(getByText('Logged in')).toBeTruthy());
+});


### PR DESCRIPTION
## Summary
- implement material theme and supply to PaperProvider
- complete login/logout actions with notifications
- switch navigation stack based on auth state
- integrate Material 3 components in Login and Notifications screens
- add test for login snackbar

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ea35623883319145b87b0bdf91cc