### PR TITLE
Update flake node and devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,18 @@
   outputs = { self, nixpkgs, flake-utils, nodejs }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs { inherit system; }; 
-        node = pkgs.nodejs_18;
+        pkgs = import nixpkgs { inherit system; };
+        node = nodejs.packages.${system}.nodejs;
       in
       {
         devShells.default = pkgs.mkShell {
-          buildInputs = [ node pkgs.yarn pkgs.watchman pkgs.android-tools ];
+          buildInputs = [
+            node
+            pkgs.nodePackages.react-native-cli
+            pkgs.yarn
+            pkgs.watchman
+            pkgs.android-tools
+          ];
         };
 
         packages.app = pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
## Summary
- use node from flake input instead of nixpkgs
- include React Native CLI and yarn classic in devShell

## Testing
- `yarn test` *(fails: react-native-testing-library: No candidates found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ea32fc808331a78f6949cee03536