### PR TITLE
Add camera screen using image picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
     "axios": "^1.6.8",
-    "react-native-paper": "^5.10.3"
+    "react-native-paper": "^5.10.3",
+    "react-native-image-picker": "^8.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -2,15 +2,18 @@ import React, { createContext, useContext, useReducer } from 'react';
 
 interface State {
   user: string | null;
+  images: string[];
 }
 
 const initialState: State = {
   user: null,
+  images: [],
 };
 
 type Action =
   | { type: 'login'; user: string }
-  | { type: 'logout' };
+  | { type: 'logout' }
+  | { type: 'addImage'; uri: string };
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -18,15 +21,23 @@ function reducer(state: State, action: Action): State {
       return { ...state, user: action.user };
     case 'logout':
       return { ...state, user: null };
+    case 'addImage':
+      return { ...state, images: [...state.images, action.uri] };
     default:
       return state;
   }
 }
 
-const AppContext = createContext<{ state: State; dispatch: React.Dispatch<Action>; login: (email: string, password: string) => void }>({
+const AppContext = createContext<{
+  state: State;
+  dispatch: React.Dispatch<Action>;
+  login: (email: string, password: string) => void;
+  addImage: (uri: string) => void;
+}>({
   state: initialState,
   dispatch: () => null,
   login: () => {},
+  addImage: () => {},
 });
 
 export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -36,8 +47,12 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     dispatch({ type: 'login', user: email });
   };
 
+  const addImage = (uri: string) => {
+    dispatch({ type: 'addImage', uri });
+  };
+
   return (
-    <AppContext.Provider value={{ state, dispatch, login }}>
+    <AppContext.Provider value={{ state, dispatch, login, addImage }}>
       {children}
     </AppContext.Provider>
   );

--- a/src/screens/CameraScreen.tsx
+++ b/src/screens/CameraScreen.tsx
@@ -1,10 +1,68 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import {
+  Button,
+  ScrollView,
+  Image,
+  StyleSheet,
+  Share,
+} from 'react-native';
+import {
+  launchCamera,
+  launchImageLibrary,
+  ImagePickerResponse,
+} from 'react-native-image-picker';
+import { useApp } from '../context/AppContext';
 
 export default function CameraScreen() {
+  const { state, addImage } = useApp();
+
+  const handleResult = (response: ImagePickerResponse) => {
+    if (response.assets && response.assets.length > 0) {
+      const uri = response.assets[0].uri;
+      if (uri) {
+        addImage(uri);
+      }
+    }
+  };
+
+  const openCamera = () => {
+    launchCamera({ mediaType: 'photo', saveToPhotos: true }, handleResult);
+  };
+
+  const openLibrary = () => {
+    launchImageLibrary({ mediaType: 'photo' }, handleResult);
+  };
+
+  const shareLast = () => {
+    const uri = state.images[state.images.length - 1];
+    if (uri) {
+      Share.share({ url: uri });
+    }
+  };
+
   return (
-    <View>
-      <Text>Camera Screen</Text>
-    </View>
+    <ScrollView contentContainerStyle={styles.container}>
+      <Button title="Open Camera" onPress={openCamera} />
+      <Button title="Import Image" onPress={openLibrary} />
+      <Button
+        title="Share Last Image"
+        onPress={shareLast}
+        disabled={state.images.length === 0}
+      />
+      {state.images.map((uri) => (
+        <Image key={uri} source={{ uri }} style={styles.image} />
+      ))}
+    </ScrollView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  image: {
+    width: '100%',
+    height: 200,
+    marginTop: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- add `react-native-image-picker` dependency
- store captured images in app context
- implement camera screen with capture, import, and share functionality

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6841ea3140b083318e7f9addec2ceace