### PR TITLE
Update product API endpoint

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,9 +1,19 @@
 import axios from 'axios';
 import { Product } from '../hooks/useProducts';
 
+const API_URL = 'http://localhost:3000';
+const PAGE_SIZE = 100;
+const MAX_ITEMS = 10000;
+
 export async function fetchProducts(page: number): Promise<Product[]> {
-  const response = await axios.get('https://example.com/products', {
-    params: { page },
+  const start = page * PAGE_SIZE;
+  if (start >= MAX_ITEMS) return [];
+
+  const response = await axios.get<Product[]>(`${API_URL}/products`, {
+    params: {
+      _start: start,
+      _limit: PAGE_SIZE,
+    },
   });
   return response.data;
 }


### PR DESCRIPTION
## Summary
- use a localhost mock API instead of example.com
- paginate product fetches in batches of 100 items up to 10k

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef5c27008331ba289a99c6263480